### PR TITLE
Feature implementation from commits 1a1bb82..da489ef

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ With SWR, components will get **a stream of data updates constantly and automati
 import useSWR from 'swr'
 
 function Profile() {
-  const { data, error } = useSWR('/api/user', fetcher)
+  const { data, error, isLoading } = useSWR('/api/user', fetcher)
 
   if (error) return <div>failed to load</div>
-  if (!data) return <div>loading...</div>
+  if (isLoading) return <div>loading...</div>
   return <div>hello {data.name}!</div>
 }
 ```
@@ -68,9 +68,9 @@ In this example, the React Hook `useSWR` accepts a `key` and a `fetcher` functio
 The `key` is a unique identifier of the request, normally the URL of the API. And the `fetcher` accepts
 `key` as its parameter and returns the data asynchronously.
 
-`useSWR` also returns 2 values: `data` and `error`. When the request (fetcher) is not yet finished,
-`data` will be `undefined`. And when we get a response, it sets `data` and `error` based on the result
-of `fetcher` and rerenders the component.
+`useSWR` also returns 3 values: `data`, `isLoading` and `error`. When the request (fetcher) is not yet finished,
+`data` will be `undefined` and `isLoading` will be `true`. When we get a response, it sets `data` and `error` based on the result
+of `fetcher`, `isLoading` to false and rerenders the component.
 
 Note that `fetcher` can be any asynchronous function, you can use your favourite data-fetching
 library to handle that part.

--- a/_internal/src/types.ts
+++ b/_internal/src/types.ts
@@ -295,7 +295,7 @@ export type Middleware = (
   config: SWRConfiguration<Data, Error, BareFetcher<Data>>
 ) => SWRResponse<Data, Error>
 
-type ArgumentsTuple = [any, ...unknown[]] | readonly [any, ...unknown[]]
+type ArgumentsTuple = readonly [any, ...unknown[]]
 export type Arguments =
   | string
   | ArgumentsTuple

--- a/_internal/src/types.ts
+++ b/_internal/src/types.ts
@@ -394,13 +394,10 @@ export interface ScopedMutator {
  * @typeParam Data - The type of the data related to the key
  * @typeParam MutationData - The type of the data returned by the mutator
  */
-export type KeyedMutator<Data> = <MutationData>(
-  data?:
-    | MutationData
-    | Promise<MutationData | undefined>
-    | MutatorCallback<MutationData>,
+export type KeyedMutator<Data> = <MutationData = Data>(
+  data?: Data | Promise<Data | undefined> | MutatorCallback<Data>,
   opts?: boolean | MutatorOptions<Data, MutationData>
-) => Promise<MutationData | undefined>
+) => Promise<Data | MutationData | undefined>
 
 export type SWRConfiguration<
   Data = any,

--- a/_internal/src/types.ts
+++ b/_internal/src/types.ts
@@ -231,6 +231,10 @@ export interface SWRHook {
     key: SWRKey,
     fetcher: Fetcher<Data, SWRKey> | null
   ): SWRResponse<Data, Error>
+  <Data = any, Error = any, SWRKey extends Key = Key>(
+    key: SWRKey,
+    fetcher: Fetcher<Data, SWRKey> | null
+  ): SWRResponse<Data, Error>
   <
     Data = any,
     Error = any,
@@ -259,10 +263,6 @@ export interface SWRHook {
     config: SWROptions
   ): SWRResponse<Data, Error, SWROptions>
   <Data = any, Error = any>(key: Key): SWRResponse<Data, Error>
-  <Data = any, Error = any>(
-    key: Key,
-    fetcher: BareFetcher<Data> | null
-  ): SWRResponse<Data, Error>
   <
     Data = any,
     Error = any,

--- a/core/src/use-swr.ts
+++ b/core/src/use-swr.ts
@@ -754,9 +754,9 @@ export { unstable_serialize } from './serialize'
  * ```jsx
  * import useSWR from 'swr'
  * function Profile() {
- *   const { data, error } = useSWR('/api/user', fetcher)
+ *   const { data, error, isLoading } = useSWR('/api/user', fetcher)
  *   if (error) return <div>failed to load</div>
- *   if (!data) return <div>loading...</div>
+ *   if (isLoading) return <div>loading...</div>
  *   return <div>hello {data.name}!</div>
  * }
  * ```

--- a/core/src/use-swr.ts
+++ b/core/src/use-swr.ts
@@ -5,7 +5,7 @@ import ReactExports, {
   useDebugValue,
   useMemo
 } from 'react'
-import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
+import { useSyncExternalStore } from 'use-sync-external-store/shim'
 
 import {
   defaultConfig,

--- a/core/src/use-swr.ts
+++ b/core/src/use-swr.ts
@@ -5,7 +5,7 @@ import ReactExports, {
   useDebugValue,
   useMemo
 } from 'react'
-import { useSyncExternalStore } from 'use-sync-external-store/shim'
+import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
 
 import {
   defaultConfig,

--- a/infinite/src/index.ts
+++ b/infinite/src/index.ts
@@ -232,8 +232,12 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
 
     const mutate = useCallback(
       // eslint-disable-next-line func-names
-      function <T>(
-        data?: undefined | T | Promise<T | undefined> | MutatorCallback<T>,
+      function <T = Data[]>(
+        data?:
+          | undefined
+          | Data[]
+          | Promise<Data[] | undefined>
+          | MutatorCallback<Data[]>,
         opts?: undefined | boolean | MutatorOptions<Data[], T>
       ) {
         // When passing as a boolean, it's explicitly used to disable/enable
@@ -257,8 +261,8 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
         }
 
         return arguments.length
-          ? swr.mutate<T>(data, { ...options, revalidate: shouldRevalidate })
-          : swr.mutate<T>()
+          ? swr.mutate(data, { ...options, revalidate: shouldRevalidate })
+          : swr.mutate()
       },
       // swr.mutate is always the same reference
       // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/infinite/src/index.ts
+++ b/infinite/src/index.ts
@@ -33,7 +33,7 @@ import type {
   SWRInfiniteCacheValue,
   SWRInfiniteCompareFn
 } from './types'
-import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
+import { useSyncExternalStore } from 'use-sync-external-store/shim'
 import { getFirstPageKey } from './serialize'
 
 // const INFINITE_PREFIX = '$inf$'

--- a/infinite/src/index.ts
+++ b/infinite/src/index.ts
@@ -33,7 +33,7 @@ import type {
   SWRInfiniteCacheValue,
   SWRInfiniteCompareFn
 } from './types'
-import { useSyncExternalStore } from 'use-sync-external-store/shim'
+import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
 import { getFirstPageKey } from './serialize'
 
 // const INFINITE_PREFIX = '$inf$'

--- a/mutation/src/index.ts
+++ b/mutation/src/index.ts
@@ -14,7 +14,10 @@ import type {
   SWRMutationConfiguration,
   SWRMutationResponse,
   SWRMutationHook,
-  MutationFetcher
+  MutationFetcher,
+  TriggerWithArgs,
+  TriggerWithoutArgs,
+  TriggerWithOptionsArgs
 } from './types'
 
 const mutation = (<Data, Error>() =>
@@ -160,5 +163,8 @@ export {
   SWRMutationConfiguration,
   SWRMutationResponse,
   SWRMutationHook,
-  MutationFetcher
+  MutationFetcher,
+  TriggerWithArgs,
+  TriggerWithoutArgs,
+  TriggerWithOptionsArgs
 }

--- a/mutation/src/state.ts
+++ b/mutation/src/state.ts
@@ -4,10 +4,10 @@ import { useIsomorphicLayoutEffect, IS_REACT_LEGACY } from 'swr/_internal'
 
 export const startTransition: (scope: TransitionFunction) => void =
   IS_REACT_LEGACY
-    ? React.startTransition
-    : cb => {
+    ? cb => {
         cb()
       }
+    : React.startTransition
 
 /**
  * An implementation of state with dependency-tracking.

--- a/mutation/src/types.ts
+++ b/mutation/src/types.ts
@@ -88,7 +88,7 @@ export interface TriggerWithArgs<
   ): Promise<Data | undefined>
 }
 
-interface TriggerWithOptionsArgs<
+export interface TriggerWithOptionsArgs<
   Data = any,
   Error = any,
   SWRMutationKey extends Key = Key,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swr",
-  "version": "2.2.1-beta.2",
+  "version": "2.2.1-beta.3",
   "description": "React Hooks library for remote data fetching",
   "keywords": [
     "swr",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swr",
-  "version": "2.2.1-beta.3",
+  "version": "2.2.1",
   "description": "React Hooks library for remote data fetching",
   "keywords": [
     "swr",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swr",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "React Hooks library for remote data fetching",
   "keywords": [
     "swr",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swr",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "React Hooks library for remote data fetching",
   "keywords": [
     "swr",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: false
-  excludeLinksFromLockfile: false
-
 importers:
 
   .:
@@ -3990,7 +3986,7 @@ packages:
       parse5: 7.1.2
       saxes: 6.0.0
       symbol-tree: 3.2.4
-      tough-cookie: 4.1.2
+      tough-cookie: 4.1.3
       w3c-xmlserializer: 4.0.0
       webidl-conversions: 7.0.0
       whatwg-encoding: 2.0.0
@@ -5308,8 +5304,8 @@ packages:
       is-number: 7.0.0
     dev: true
 
-  /tough-cookie@4.1.2:
-    resolution: {integrity: sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==}
+  /tough-cookie@4.1.3:
+    resolution: {integrity: sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==}
     engines: {node: '>=6'}
     dependencies:
       psl: 1.9.0
@@ -5622,3 +5618,7 @@ packages:
   /zod@3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: true
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,7 +202,7 @@ packages:
       convert-source-map: 1.8.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
-      json5: 2.2.1
+      json5: 2.2.3
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
@@ -4018,8 +4018,8 @@ packages:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
 
-  /json5@2.2.1:
-    resolution: {integrity: sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==}
+  /json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
     dev: true

--- a/test/type/fetcher.ts
+++ b/test/type/fetcher.ts
@@ -6,6 +6,8 @@ import type { Equal } from '@type-challenges/utils'
 export function useDataErrorGeneric() {
   useSWR<{ id: number }>('/api/', () => ({ id: 123 }))
   useSWR<string, any>('/api/', (key: string) => key)
+  const fetcher = ({ url }: { url: string }) => url
+  useSWR({ url: '/api' }, fetcher)
   useSWRInfinite<string[], any>(
     (index, previousPageData) => {
       expectType<Equal<number, typeof index>>(true)

--- a/test/type/mutate.ts
+++ b/test/type/mutate.ts
@@ -62,9 +62,11 @@ export function useMutatorTypes() {
 
   mutate(async () => '1')
 
+  // @ts-expect-error
   mutate(async () => 1)
 
-  mutate(async () => 1, { populateCache: false })
+  // FIXME: this should work.
+  // mutate(async () => 1, { populateCache: false })
 }
 
 export function useConfigMutate() {

--- a/test/type/mutate.ts
+++ b/test/type/mutate.ts
@@ -61,12 +61,12 @@ export function useMutatorTypes() {
   const { mutate } = useSWR<string>('')
 
   mutate(async () => '1')
+  mutate(async () => '1', { populateCache: false })
 
   // @ts-expect-error
   mutate(async () => 1)
-
-  // FIXME: this should work.
-  // mutate(async () => 1, { populateCache: false })
+  // @ts-expect-error
+  mutate(async () => 1, { populateCache: false })
 }
 
 export function useConfigMutate() {

--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -1580,10 +1580,11 @@ describe('useSWR - local mutation', () => {
     }
 
     function Page() {
-      const { data, mutate } = useSWR(key, () => serverData)
+      const { mutate } = useSWRConfig()
+      const { data } = useSWR(key, () => serverData)
 
       appendData = () => {
-        return mutate(sendRequest('cherry'), {
+        return mutate<string[], string>(key, sendRequest('cherry'), {
           optimisticData: [...data, 'cherry (optimistic)'],
           populateCache: (result, currentData) => [
             ...currentData,


### PR DESCRIPTION
This PR contains changes from a range of commits from the original repository.

**Commit Range:** `1a1bb82..da489ef`
**Files Changed:** 12 (8 programming files)
**Programming Ratio:** 66.7%

**Commits included:**
- Revert "Remove `index.js` suffix of `use-sync-external-store/shim` to support React Native" (#2802)
- 2.2.3
- test: update tests, use matched types for mutate api (#2781)
- types: export mutation types (#2780)
- fix: default to fetch type in keyed mutator (#2753)
- Remove `index.js` suffix of `use-sync-external-store/shim` to support React Native (#2767)
- fix: remove permissive type (#2759)
- 2.2.2
- fix: simplify `ArgumentsTuple` (#2761)
- fix: It should use startTransition only when IS_REACT_LEGACY is false (#2756)
... and 5 more commits