### PR TITLE
Feature implementation from commits d14cef2..a2bb5ae

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ With SWR, components will get **a stream of data updates constantly and automati
 import useSWR from 'swr'
 
 function Profile() {
-  const { data, error } = useSWR('/api/user', fetcher)
+  const { data, error, isLoading } = useSWR('/api/user', fetcher)
 
   if (error) return <div>failed to load</div>
-  if (!data) return <div>loading...</div>
+  if (isLoading) return <div>loading...</div>
   return <div>hello {data.name}!</div>
 }
 ```
@@ -68,9 +68,9 @@ In this example, the React Hook `useSWR` accepts a `key` and a `fetcher` functio
 The `key` is a unique identifier of the request, normally the URL of the API. And the `fetcher` accepts
 `key` as its parameter and returns the data asynchronously.
 
-`useSWR` also returns 2 values: `data` and `error`. When the request (fetcher) is not yet finished,
-`data` will be `undefined`. And when we get a response, it sets `data` and `error` based on the result
-of `fetcher` and rerenders the component.
+`useSWR` also returns 3 values: `data`, `isLoading` and `error`. When the request (fetcher) is not yet finished,
+`data` will be `undefined` and `isLoading` will be `true`. When we get a response, it sets `data` and `error` based on the result
+of `fetcher`, `isLoading` to false and rerenders the component.
 
 Note that `fetcher` can be any asynchronous function, you can use your favourite data-fetching
 library to handle that part.

--- a/_internal/src/types.ts
+++ b/_internal/src/types.ts
@@ -310,11 +310,15 @@ export type MutatorCallback<Data = any> = (
   currentData?: Data
 ) => Promise<undefined | Data> | undefined | Data
 
-export type MutatorOptions<Data = any> = {
+/**
+ * @typeParam Data - The type of the data related to the key
+ * @typeParam MutationData - The type of the data returned by the mutator
+ */
+export type MutatorOptions<Data = any, MutationData = Data> = {
   revalidate?: boolean
   populateCache?:
     | boolean
-    | ((result: any, currentData: Data | undefined) => Data)
+    | ((result: MutationData, currentData: Data | undefined) => Data)
   optimisticData?:
     | Data
     | ((currentData: Data | undefined, displayedData: Data | undefined) => Data)
@@ -365,23 +369,38 @@ export type MutatorWrapper<Fn> = Fn extends (
 
 export type Mutator<Data = any> = MutatorWrapper<MutatorFn<Data>>
 
-export interface ScopedMutator<Data = any> {
-  <T = Data>(
+export interface ScopedMutator {
+  /**
+   * @typeParam Data - The type of the data related to the key
+   * @typeParam MutationData - The type of the data returned by the mutator
+   */
+  <Data = any, MutationData = Data>(
     matcher: (key?: Arguments) => boolean,
-    data?: T | Promise<T> | MutatorCallback<T>,
-    opts?: boolean | MutatorOptions<Data>
-  ): Promise<Array<T | undefined>>
-  <T = Data>(
+    data?: MutationData | Promise<MutationData> | MutatorCallback<MutationData>,
+    opts?: boolean | MutatorOptions<Data, MutationData>
+  ): Promise<Array<MutationData | undefined>>
+  /**
+   * @typeParam Data - The type of the data related to the key
+   * @typeParam MutationData - The type of the data returned by the mutator
+   */
+  <Data = any, T = Data>(
     key: Arguments,
     data?: T | Promise<T> | MutatorCallback<T>,
-    opts?: boolean | MutatorOptions<Data>
+    opts?: boolean | MutatorOptions<Data, T>
   ): Promise<T | undefined>
 }
 
-export type KeyedMutator<Data> = (
-  data?: Data | Promise<Data | undefined> | MutatorCallback<Data>,
-  opts?: boolean | MutatorOptions<Data>
-) => Promise<Data | undefined>
+/**
+ * @typeParam Data - The type of the data related to the key
+ * @typeParam MutationData - The type of the data returned by the mutator
+ */
+export type KeyedMutator<Data> = <MutationData>(
+  data?:
+    | MutationData
+    | Promise<MutationData | undefined>
+    | MutatorCallback<MutationData>,
+  opts?: boolean | MutatorOptions<Data, MutationData>
+) => Promise<MutationData | undefined>
 
 export type SWRConfiguration<
   Data = any,

--- a/_internal/src/types.ts
+++ b/_internal/src/types.ts
@@ -295,7 +295,7 @@ export type Middleware = (
   config: SWRConfiguration<Data, Error, BareFetcher<Data>>
 ) => SWRResponse<Data, Error>
 
-type ArgumentsTuple = [any, ...unknown[]] | readonly [any, ...unknown[]]
+type ArgumentsTuple = readonly [any, ...unknown[]]
 export type Arguments =
   | string
   | ArgumentsTuple

--- a/_internal/src/types.ts
+++ b/_internal/src/types.ts
@@ -231,6 +231,10 @@ export interface SWRHook {
     key: SWRKey,
     fetcher: Fetcher<Data, SWRKey> | null
   ): SWRResponse<Data, Error>
+  <Data = any, Error = any, SWRKey extends Key = Key>(
+    key: SWRKey,
+    fetcher: Fetcher<Data, SWRKey> | null
+  ): SWRResponse<Data, Error>
   <
     Data = any,
     Error = any,
@@ -259,10 +263,6 @@ export interface SWRHook {
     config: SWROptions
   ): SWRResponse<Data, Error, SWROptions>
   <Data = any, Error = any>(key: Key): SWRResponse<Data, Error>
-  <Data = any, Error = any>(
-    key: Key,
-    fetcher: BareFetcher<Data> | null
-  ): SWRResponse<Data, Error>
   <
     Data = any,
     Error = any,

--- a/_internal/src/utils/cache.ts
+++ b/_internal/src/utils/cache.ts
@@ -27,8 +27,8 @@ export const initCache = <Data = any>(
   provider: Cache<Data>,
   options?: Partial<ProviderConfiguration>
 ):
-  | [Cache<Data>, ScopedMutator<Data>, () => void, () => void]
-  | [Cache<Data>, ScopedMutator<Data>]
+  | [Cache<Data>, ScopedMutator, () => void, () => void]
+  | [Cache<Data>, ScopedMutator]
   | undefined => {
   // The global state for a specific provider will be used to deduplicate
   // requests and store listeners. As well as a mutate function that is bound to
@@ -43,10 +43,7 @@ export const initCache = <Data = any>(
     // new mutate function.
     const EVENT_REVALIDATORS = {}
 
-    const mutate = internalMutate.bind(
-      UNDEFINED,
-      provider
-    ) as ScopedMutator<Data>
+    const mutate = internalMutate.bind(UNDEFINED, provider) as ScopedMutator
     let unmount = noop
 
     const subscriptions: Record<string, ((current: any, prev: any) => void)[]> =

--- a/_internal/src/utils/config.ts
+++ b/_internal/src/utils/config.ts
@@ -41,7 +41,7 @@ const compare = (currentData: any, newData: any) =>
   stableHash(currentData) == stableHash(newData)
 
 // Default cache provider
-const [cache, mutate] = initCache(new Map()) as [Cache<any>, ScopedMutator<any>]
+const [cache, mutate] = initCache(new Map()) as [Cache<any>, ScopedMutator]
 export { cache, mutate, compare }
 
 // Default config

--- a/_internal/src/utils/mutate.ts
+++ b/_internal/src/utils/mutate.ts
@@ -97,8 +97,8 @@ export async function internalMutate<Data>(
       cache
     ) as GlobalState
 
-    const revalidators = EVENT_REVALIDATORS[key]
     const startRevalidate = () => {
+      const revalidators = EVENT_REVALIDATORS[key]
       if (revalidate) {
         // Invalidate the key by deleting the concurrent request markers so new
         // requests will not be deduped.

--- a/_internal/src/utils/preload.ts
+++ b/_internal/src/utils/preload.ts
@@ -48,14 +48,15 @@ export const middleware: Middleware =
         const [key] = serialize(key_)
         const [, , , PRELOAD] = SWRGlobalState.get(cache) as GlobalState
 
-        let normalizedKey = key
         if (key.startsWith(INFINITE_PREFIX)) {
-          normalizedKey = key.slice(INFINITE_PREFIX.length)
+          // we want the infinite fetcher to be called.
+          // handling of the PRELOAD cache happens there.
+          return fetcher_(...args)
         }
 
-        const req = PRELOAD[normalizedKey]
+        const req = PRELOAD[key]
         if (isUndefined(req)) return fetcher_(...args)
-        delete PRELOAD[normalizedKey]
+        delete PRELOAD[key]
         return req
       })
     return useSWRNext(key_, fetcher, config)

--- a/core/src/use-swr.ts
+++ b/core/src/use-swr.ts
@@ -754,9 +754,9 @@ export { unstable_serialize } from './serialize'
  * ```jsx
  * import useSWR from 'swr'
  * function Profile() {
- *   const { data, error } = useSWR('/api/user', fetcher)
+ *   const { data, error, isLoading } = useSWR('/api/user', fetcher)
  *   if (error) return <div>failed to load</div>
- *   if (!data) return <div>loading...</div>
+ *   if (isLoading) return <div>loading...</div>
  *   return <div>hello {data.name}!</div>
  * }
  * ```

--- a/core/src/use-swr.ts
+++ b/core/src/use-swr.ts
@@ -550,7 +550,7 @@ export const useSWRHandler = <Data = any, Error = any>(
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const boundMutate: SWRResponse<Data, Error>['mutate'] = useCallback(
     // Use callback to make sure `keyRef.current` returns latest result every time
-    (...args) => {
+    (...args: any[]) => {
       return internalMutate(cache, keyRef.current, ...args)
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/core/src/use-swr.ts
+++ b/core/src/use-swr.ts
@@ -5,7 +5,7 @@ import ReactExports, {
   useDebugValue,
   useMemo
 } from 'react'
-import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
+import { useSyncExternalStore } from 'use-sync-external-store/shim'
 
 import {
   defaultConfig,

--- a/infinite/src/index.ts
+++ b/infinite/src/index.ts
@@ -169,22 +169,8 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
             SWRInfiniteCacheValue<Data, any>
           >(cache, pageKey)
 
-          const hasPreloadedRequest = pageKey in PRELOAD
           // Get the cached page data.
           let pageData = getSWRCache().data as Data
-
-          if (hasPreloadedRequest) {
-            const req = PRELOAD[pageKey]
-            // delete the preload cache key before resolving it
-            // in case there's an error
-            delete PRELOAD[pageKey]
-            // get the page data from the preload cache
-            pageData = await req
-            // set the SWR cache with the preloaded data
-            setSWRCache({ data: pageData, _k: pageArg })
-            // remove the preload cache key to prevent memory leak
-          }
-
           // should fetch (or revalidate) if:
           // - `revalidateAll` is enabled
           // - `mutate()` called
@@ -203,7 +189,17 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
               !config.compare(cacheData[i], pageData))
           if (fn && shouldFetchPage) {
             const revalidate = async () => {
-              pageData = await fn(pageArg)
+              const hasPreloadedRequest = pageKey in PRELOAD
+              if (!hasPreloadedRequest) {
+                pageData = await fn(pageArg)
+              } else {
+                const req = PRELOAD[pageKey]
+                // delete the preload cache key before resolving it
+                // in case there's an error
+                delete PRELOAD[pageKey]
+                // get the page data from the preload cache
+                pageData = await req
+              }
               setSWRCache({ data: pageData, _k: pageArg })
               data[i] = pageData
             }

--- a/infinite/src/index.ts
+++ b/infinite/src/index.ts
@@ -232,13 +232,9 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
 
     const mutate = useCallback(
       // eslint-disable-next-line func-names
-      function (
-        data?:
-          | undefined
-          | Data[]
-          | Promise<Data[] | undefined>
-          | MutatorCallback<Data[]>,
-        opts?: undefined | boolean | MutatorOptions<Data[]>
+      function <T>(
+        data?: undefined | T | Promise<T | undefined> | MutatorCallback<T>,
+        opts?: undefined | boolean | MutatorOptions<Data[], T>
       ) {
         // When passing as a boolean, it's explicitly used to disable/enable
         // revalidation.
@@ -261,8 +257,8 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
         }
 
         return arguments.length
-          ? swr.mutate(data, { ...options, revalidate: shouldRevalidate })
-          : swr.mutate()
+          ? swr.mutate<T>(data, { ...options, revalidate: shouldRevalidate })
+          : swr.mutate<T>()
       },
       // swr.mutate is always the same reference
       // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/infinite/src/index.ts
+++ b/infinite/src/index.ts
@@ -33,7 +33,7 @@ import type {
   SWRInfiniteCacheValue,
   SWRInfiniteCompareFn
 } from './types'
-import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
+import { useSyncExternalStore } from 'use-sync-external-store/shim'
 import { getFirstPageKey } from './serialize'
 
 // const INFINITE_PREFIX = '$inf$'

--- a/mutation/src/state.ts
+++ b/mutation/src/state.ts
@@ -4,10 +4,10 @@ import { useIsomorphicLayoutEffect, IS_REACT_LEGACY } from 'swr/_internal'
 
 export const startTransition: (scope: TransitionFunction) => void =
   IS_REACT_LEGACY
-    ? React.startTransition
-    : cb => {
+    ? cb => {
         cb()
       }
+    : React.startTransition
 
 /**
  * An implementation of state with dependency-tracking.

--- a/mutation/src/types.ts
+++ b/mutation/src/types.ts
@@ -190,31 +190,13 @@ export interface SWRMutationResponse<
 }
 
 export interface SWRMutationHook {
-  <Data = any, Error = any, SWRMutationKey extends Key = Key, ExtraArg = never>(
-    /**
-     * The key of the resource that will be mutated. It should be the same key
-     * used in the `useSWR` hook so SWR can handle revalidation and race
-     * conditions for that resource.
-     */
-    key: SWRMutationKey,
-    /**
-     * The function to trigger the mutation that accepts the key, extra argument
-     * and options. For example:
-     *
-     * ```jsx
-     * (api, data) => fetch(api, {
-     *   method: 'POST',
-     *   body: JSON.stringify(data)
-     * })
-     * ```
-     */
-    fetcher: MutationFetcher<Data, SWRMutationKey, ExtraArg>,
-    /**
-     * Extra options for the mutation hook.
-     */
-    options?: SWRMutationConfiguration<Data, Error, SWRMutationKey, ExtraArg>
-  ): SWRMutationResponse<Data, Error, SWRMutationKey, ExtraArg>
-  <Data = any, Error = any, SWRMutationKey extends Key = Key, ExtraArg = never>(
+  <
+    Data = any,
+    Error = any,
+    SWRMutationKey extends Key = Key,
+    ExtraArg = never,
+    SWRData = Data
+  >(
     /**
      * The key of the resource that will be mutated. It should be the same key
      * used in the `useSWR` hook so SWR can handle revalidation and race
@@ -240,10 +222,53 @@ export interface SWRMutationHook {
       Data,
       Error,
       SWRMutationKey,
-      ExtraArg
+      ExtraArg,
+      SWRData
+    >
+  ): SWRMutationResponse<Data, Error, SWRMutationKey, ExtraArg>
+  <
+    Data = any,
+    Error = any,
+    SWRMutationKey extends Key = Key,
+    ExtraArg = never,
+    SWRData = Data
+  >(
+    /**
+     * The key of the resource that will be mutated. It should be the same key
+     * used in the `useSWR` hook so SWR can handle revalidation and race
+     * conditions for that resource.
+     */
+    key: SWRMutationKey,
+    /**
+     * The function to trigger the mutation that accepts the key, extra argument
+     * and options. For example:
+     *
+     * ```jsx
+     * (api, data) => fetch(api, {
+     *   method: 'POST',
+     *   body: JSON.stringify(data)
+     * })
+     * ```
+     */
+    fetcher: MutationFetcher<Data, SWRMutationKey, ExtraArg>,
+    /**
+     * Extra options for the mutation hook.
+     */
+    options?: SWRMutationConfiguration<
+      Data,
+      Error,
+      SWRMutationKey,
+      ExtraArg,
+      SWRData
     > & { throwOnError: false }
   ): SWRMutationResponse<Data | undefined, Error, SWRMutationKey, ExtraArg>
-  <Data = any, Error = any, SWRMutationKey extends Key = Key, ExtraArg = never>(
+  <
+    Data = any,
+    Error = any,
+    SWRMutationKey extends Key = Key,
+    ExtraArg = never,
+    SWRData = Data
+  >(
     /**
      * The key of the resource that will be mutated. It should be the same key
      * used in the `useSWR` hook so SWR can handle revalidation and race
@@ -269,7 +294,8 @@ export interface SWRMutationHook {
       Data,
       Error,
       SWRMutationKey,
-      ExtraArg
+      ExtraArg,
+      SWRData
     > & { throwOnError: true }
   ): SWRMutationResponse<Data, Error, SWRMutationKey, ExtraArg>
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swr",
-  "version": "2.2.1-beta.2",
+  "version": "2.2.1-beta.3",
   "description": "React Hooks library for remote data fetching",
   "keywords": [
     "swr",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swr",
-  "version": "2.2.1-beta.1",
+  "version": "2.2.1-beta.2",
   "description": "React Hooks library for remote data fetching",
   "keywords": [
     "swr",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swr",
-  "version": "2.2.1-beta.3",
+  "version": "2.2.1",
   "description": "React Hooks library for remote data fetching",
   "keywords": [
     "swr",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swr",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "React Hooks library for remote data fetching",
   "keywords": [
     "swr",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: false
-  excludeLinksFromLockfile: false
-
 importers:
 
   .:
@@ -3990,7 +3986,7 @@ packages:
       parse5: 7.1.2
       saxes: 6.0.0
       symbol-tree: 3.2.4
-      tough-cookie: 4.1.2
+      tough-cookie: 4.1.3
       w3c-xmlserializer: 4.0.0
       webidl-conversions: 7.0.0
       whatwg-encoding: 2.0.0
@@ -5308,8 +5304,8 @@ packages:
       is-number: 7.0.0
     dev: true
 
-  /tough-cookie@4.1.2:
-    resolution: {integrity: sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==}
+  /tough-cookie@4.1.3:
+    resolution: {integrity: sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==}
     engines: {node: '>=6'}
     dependencies:
       psl: 1.9.0
@@ -5622,3 +5618,7 @@ packages:
   /zod@3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: true
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,7 +202,7 @@ packages:
       convert-source-map: 1.8.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
-      json5: 2.2.1
+      json5: 2.2.3
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
@@ -4018,8 +4018,8 @@ packages:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
 
-  /json5@2.2.1:
-    resolution: {integrity: sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==}
+  /json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
     dev: true

--- a/subscription/src/types.ts
+++ b/subscription/src/types.ts
@@ -1,7 +1,7 @@
 import type { Key, SWRConfiguration, MutatorCallback } from 'swr'
 
 export type SWRSubscriptionOptions<Data = any, Error = any> = {
-  next: <T = Data>(err?: Error | null, data?: Data | MutatorCallback<T>) => void
+  next: (err?: Error | null, data?: Data | MutatorCallback<Data>) => void
 }
 
 export type SWRSubscription<

--- a/test/type/fetcher.ts
+++ b/test/type/fetcher.ts
@@ -6,6 +6,8 @@ import type { Equal } from '@type-challenges/utils'
 export function useDataErrorGeneric() {
   useSWR<{ id: number }>('/api/', () => ({ id: 123 }))
   useSWR<string, any>('/api/', (key: string) => key)
+  const fetcher = ({ url }: { url: string }) => url
+  useSWR({ url: '/api' }, fetcher)
   useSWRInfinite<string[], any>(
     (index, previousPageData) => {
       expectType<Equal<number, typeof index>>(true)

--- a/test/type/mutate.ts
+++ b/test/type/mutate.ts
@@ -62,11 +62,9 @@ export function useMutatorTypes() {
 
   mutate(async () => '1')
 
-  // @ts-expect-error
   mutate(async () => 1)
 
-  // FIXME: this should work.
-  // mutate(async () => 1, { populateCache: false })
+  mutate(async () => 1, { populateCache: false })
 }
 
 export function useConfigMutate() {
@@ -85,7 +83,7 @@ export function useConfigMutate() {
   )
 
   expect<Promise<any>>(
-    mutate('string', data => {
+    mutate('string', (data?: string) => {
       expectType<string | undefined>(data)
       return '0'
     })

--- a/test/use-swr-infinite-preload.test.tsx
+++ b/test/use-swr-infinite-preload.test.tsx
@@ -8,6 +8,21 @@ describe('useSWRInfinite - preload', () => {
   const getKeyFunction = (key: string) => (index: number) =>
     `page-${index}-${key}`
 
+  it('preloading useSWRInfinite should produce the same result', async () => {
+    const key = createKey()
+    const getKey = getKeyFunction(key)
+
+    const fetcher = jest.fn(() => createResponse('foo'))
+    function Page() {
+      const { data } = useSWRInfinite(getKey, fetcher)
+      return <div>data:{Array.isArray(data) ? 'true' : 'false'}</div>
+    }
+
+    preload(getKey(0), fetcher)
+    renderWithConfig(<Page />)
+    await screen.findByText('data:true')
+  })
+
   it('preload the fetcher function', async () => {
     const key = createKey()
     const getKey = getKeyFunction(key)

--- a/test/use-swr-infinite.test.tsx
+++ b/test/use-swr-infinite.test.tsx
@@ -1394,7 +1394,7 @@ describe('useSWRInfinite', () => {
           <button
             onClick={() => {
               mutate(updater, {
-                populateCache: (result: string, currentData: string[]) => {
+                populateCache: (result: string[], currentData: string[]) => {
                   return [...currentData, ...result]
                 },
                 revalidate: false
@@ -1476,7 +1476,7 @@ describe('useSWRInfinite', () => {
             onClick={() => {
               mutate(updater, {
                 optimisticData: current => [current[0], [...current[1], 'B4']],
-                populateCache: (result: string, currentData: string[]) => {
+                populateCache: (result: string[], currentData: string[]) => {
                   return [currentData[0], [...currentData[1], ...result]]
                 },
                 revalidate: false

--- a/test/use-swr-infinite.test.tsx
+++ b/test/use-swr-infinite.test.tsx
@@ -24,6 +24,7 @@ describe('useSWRInfinite', () => {
       return (
         <div>
           <div>data:{data}</div>
+          <div>isArray:{Array.isArray(data) ? 'true' : 'false'}</div>
           <div>error:{error}</div>
           <div>isValidating:{isValidating.toString()}</div>
         </div>
@@ -34,6 +35,7 @@ describe('useSWRInfinite', () => {
     screen.getByText('data:')
 
     await screen.findByText(`data:page-0-${key}`)
+    await screen.findByText(`isArray:true`)
     await screen.findByText(`error:`)
     await screen.findByText(`isValidating:false`)
   })

--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -1365,7 +1365,7 @@ describe('useSWR - local mutation', () => {
         }
       )
     })
-
+    await sleep(30)
     try {
       // data == "baz", then reverted back to "bar"
       await executeWithoutBatching(() =>
@@ -1567,8 +1567,8 @@ describe('useSWR - local mutation', () => {
 
     let appendData
 
-    const sendRequest = <Data,>(newItem) => {
-      return new Promise<Data>(res =>
+    const sendRequest = (newItem: string) => {
+      return new Promise<string>(res =>
         setTimeout(() => {
           // The server capitalizes the new item.
           const modifiedData =


### PR DESCRIPTION
# PR Summary

Enhance SWR Hook Type Support and Improve Mutation Behavior

## Overview

This PR enhances TypeScript type support for SWR hooks by modifying interface overloads and adds preloading capability to the SWR infinite hook. It also improves the mutation behavior with non-blocking revalidation.

## Change Types

| Type         | Description                            |
|--------------|----------------------------------------|
| Enhancement  | Improved TypeScript type support for SWR hooks |
| Enhancement  | Added preloading capability for SWR infinite hook |
| Refactor     | Modified mutation behavior with non-blocking revalidation |

---

## Affected Modules

| Module / File          | Change Description                       |
|------------------------|------------------------------------------|
| `src/types.ts`         | Added interface overload to support broader Key type; Removed overload signature from SWRHook interface |
| `src/utils/mutate.ts`  | Modified internalMutate function to handle populateCache differently with non-blocking revalidation |
| `src/use-swr.ts`       | Added TypeScript type annotation to spread parameter in boundMutate callback |
| `src/index.ts`         | Added PRELOAD state extraction from SWRGlobalState for infinite hook |

---

## Breaking Changes

* Removed an overload signature from the SWRHook interface that accepts a key and fetcher parameter
* Changed behavior of internalMutate function which may affect existing implementations